### PR TITLE
新增引文和 bilibili 解析

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bmybbs/bmybbs-content-parser",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bmybbs/bmybbs-content-parser",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"description": "This is a library to convert bmybbs content, including articles and mails, to HTML format.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,6 @@
 export interface ParseStates {
 	isInCodeBlock: boolean;
+	isInBlockQuote?: boolean;
 }
 
 export interface Attach {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,10 @@ const bmyParser: BMYParser = (content) => {
 		html.push("</blockquote>");
 	}
 
+	if (config.states.isInCodeBlock) {
+		html.push("</code></pre>");
+	}
+
 	html.push("</article>");
 	return html.join("");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,10 @@ const bmyParser: BMYParser = (content) => {
 	});
 
 	const line_array = content.text.split("\n");
+	const config = { states, attaches };
+
 	for (const line of line_array) {
-		const result = lineParser(line, { states, attaches });
+		const result = lineParser(line, config);
 		if (Array.isArray(result)) {
 			result.forEach((el) => {
 				html.push(el);
@@ -24,6 +26,10 @@ const bmyParser: BMYParser = (content) => {
 		} else {
 			html.push(result);
 		}
+	}
+
+	if (config.states.isInBlockQuote) {
+		html.push("</blockquote>");
 	}
 
 	html.push("</article>");

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ const bmyParser: BMYParser = (content) => {
 	const html = [],
 		attaches: Map<string, Attach> = new Map(),
 		states: ParseStates = {
-		isInCodeBlock: false
-	};
+			isInBlockQuote: false,
+			isInCodeBlock: false
+		};
 	html.push("<article>");
 
 	content.attaches.forEach(attach => {

--- a/src/parsers/biliParser.ts
+++ b/src/parsers/biliParser.ts
@@ -1,0 +1,9 @@
+import { LineParser } from "../definitions"
+
+const biliParser: LineParser = (line, _) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+	const bvid = encodeURIComponent(line.substring(10));
+	return `<iframe src="https://player.bilibili.com/player.html?bvid=${bvid}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" style=" width: 100%; height: 400px;"></iframe>`;
+}
+
+export default biliParser;
+

--- a/src/parsers/lineParser.ts
+++ b/src/parsers/lineParser.ts
@@ -2,6 +2,7 @@ import { LineParser } from "../definitions"
 import codeBlockParser from "./codeblockParser"
 import plainTextParser from "./plainTextParser"
 import attachParser    from "./attachParser"
+import biliParser      from "./biliParser"
 
 const BLOCKQUOTE_STR = "<blockquote>";
 const BLOCKQUOTE_CLOSE_STR = "</blockquote>";
@@ -46,6 +47,10 @@ const lineParser: LineParser = (line, config) => {
 	// 这里可能 attachname 不存在，内部切换为普通文本
 	if (line.startsWith("#attach ")) {
 		return attachParser(line, config);
+	}
+
+	if (line.startsWith("#bilibili ")) {
+		return biliParser(line, config);
 	}
 
 	return plainTextParser(line, config);

--- a/src/parsers/lineParser.ts
+++ b/src/parsers/lineParser.ts
@@ -3,7 +3,39 @@ import codeBlockParser from "./codeblockParser"
 import plainTextParser from "./plainTextParser"
 import attachParser    from "./attachParser"
 
+const BLOCKQUOTE_STR = "<blockquote>";
+const BLOCKQUOTE_CLOSE_STR = "</blockquote>";
+
 const lineParser: LineParser = (line, config) => {
+	// 优先处理引言方式
+	if (line.startsWith(": ")) {
+		if (!config.states.isInBlockQuote) {
+			config.states.isInBlockQuote = true;
+
+			const subResult = plainTextParser(line.substring(2), config);
+			if (Array.isArray(subResult)) {
+				subResult.unshift(BLOCKQUOTE_STR);
+				return subResult;
+			} else {
+				return [BLOCKQUOTE_STR, subResult];
+			}
+		} else {
+			return plainTextParser(line.substring(2), config);
+		}
+	}
+
+	if (config.states.isInBlockQuote) {
+		config.states.isInBlockQuote = false;
+		// 变更状态后递归调用
+		const subResult = lineParser(line,config);
+		if (Array.isArray(subResult)) {
+			subResult.unshift(BLOCKQUOTE_CLOSE_STR);
+			return subResult;
+		} else {
+			return [BLOCKQUOTE_CLOSE_STR, subResult];
+		}
+	}
+
 	// markdown 方式的代码块
 	// 有关 codeBlock 的格式处理，其中状态改变也交给 codeBlockParser 维护
 	if (config.states.isInCodeBlock || line.startsWith("```")) {

--- a/test/01-codeblock.test.ts
+++ b/test/01-codeblock.test.ts
@@ -41,6 +41,18 @@ describe("Code Block Parser Test", () => {
 		expect(parser(content)).toBe(result);
 	});
 
+	test("code block without close tag", () => {
+		const content = { text: "```c\n#include <stdio.h>", attaches: [] },
+			result = [
+			"<article>",
+			"<pre><code class=\"language-c\">",
+			"#include &lt;stdio.h&gt;\n",
+			"</code></pre>",
+			"</article>"
+		].join("");
+
+		expect(parser(content)).toBe(result);
+	});
 	// TODO
 });
 

--- a/test/04-quoteblockParser.test.ts
+++ b/test/04-quoteblockParser.test.ts
@@ -18,5 +18,21 @@ describe("Blockquote Parser Test", () => {
 
 		expect(parser(content)).toBe(result);
 	});
+
+	test("end with quotes", () => {
+		const content = {
+			text: "aaa\n: foo",
+			attaches: []
+		}, result = [
+			"<article>",
+			"<p>aaa</p>",
+			"<blockquote>",
+			"<p>foo</p>",
+			"</blockquote>",
+			"</article>"
+		].join("");
+
+		expect(parser(content)).toBe(result);
+	});
 });
 

--- a/test/04-quoteblockParser.test.ts
+++ b/test/04-quoteblockParser.test.ts
@@ -1,0 +1,22 @@
+import parser from "../src/index"
+
+describe("Blockquote Parser Test", () => {
+	test("text with quotes", () => {
+		const content = {
+			text: "aaa\n: foo\n: bar\nbbb",
+			attaches: []
+		}, result = [
+			"<article>",
+			"<p>aaa</p>",
+			"<blockquote>",
+			"<p>foo</p>",
+			"<p>bar</p>",
+			"</blockquote>",
+			"<p>bbb</p>",
+			"</article>"
+		].join("");
+
+		expect(parser(content)).toBe(result);
+	});
+});
+

--- a/test/05-biliParser.test.ts
+++ b/test/05-biliParser.test.ts
@@ -1,0 +1,30 @@
+import parser from "../src/index"
+
+describe("Bilibili Parser Test", () => {
+	test("general video id", () => {
+		const content = {
+			text: "#bilibili abc",
+			attaches: []
+		}, result = [
+			"<article>",
+			'<iframe src="https://player.bilibili.com/player.html?bvid=abc" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" style=" width: 100%; height: 400px;"></iframe>',
+			"</article>"
+		].join("");
+
+		expect(parser(content)).toBe(result);
+	});
+
+	test("video id with illegal chars", () => {
+		const content = {
+			text: "#bilibili a\"& ",
+			attaches: []
+		}, result = [
+			"<article>",
+			'<iframe src="https://player.bilibili.com/player.html?bvid=a%22%26%20" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" style=" width: 100%; height: 400px;"></iframe>',
+			"</article>"
+		].join("");
+
+		expect(parser(content)).toBe(result);
+	})
+});
+


### PR DESCRIPTION
1. 引文（即以 `: ` 开头的文字）放置在 `<blockquote />` 标签中。引文不做嵌套解析。
2. bilibili 的指令形式 `#bilibili $bvid`，得到使用 `<iframe />` 标签、高度 400px 宽度 100% 的嵌入式播放器，其中 `$bvid` 这个参数是视频 ID，例如 [《尤雨溪创立vue的心路历程》 Vue.js - The Documentary [转载+字幕]](https://www.bilibili.com/video/BV1iE411H71U) 对应的 `$bvid` 为 `BV1iE411H71U`，书写形式 `#bilibili BV1iE411H71U`。和 `#attach` 附件指令一样，`#bilibili` 指令也需要在独立的一行书写。
3. 更新版本到 `0.3.0`